### PR TITLE
Eliminate race conditions and fix tests

### DIFF
--- a/lib/Cro/ZeroMQ/Internal.pm6
+++ b/lib/Cro/ZeroMQ/Internal.pm6
@@ -102,7 +102,9 @@ role Cro::ZeroMQ::Source::Impure does Cro::Source does Cro::ZeroMQ::Component::I
             $!tapped = True;
             my $closer = False;
             my $messages = Supplier.new;
+            my $poller-ready = Promise.new;
             start {
+                $poller-ready.keep;
                 loop {
                     last if $closer;
                     CATCH { default { .rethrow unless $closer } }
@@ -112,6 +114,7 @@ role Cro::ZeroMQ::Source::Impure does Cro::Source does Cro::ZeroMQ::Component::I
                     }
                 }
             }
+            await $poller-ready;
             whenever $messages { emit $_ }
             CLOSE {
                 $!tapped = False;
@@ -131,7 +134,9 @@ role Cro::ZeroMQ::Source::Pure does Cro::Source does Cro::ZeroMQ::Component::Pur
             my ($ictx, $isocket) = $socket ?? ($ctx, $socket) !! self!initial;
             my $closer = False;
             my $messages = Supplier.new;
+            my $poller-ready = Promise.new;
             start {
+                $poller-ready.keep;
                 loop {
                     last if $closer;
                     CATCH { default { .rethrow unless $closer } }
@@ -141,6 +146,7 @@ role Cro::ZeroMQ::Source::Pure does Cro::Source does Cro::ZeroMQ::Component::Pur
                     }
                 }
             }
+            await $poller-ready;
             whenever $messages { emit $_ }
             CLOSE {
                 $closer = True;

--- a/lib/Cro/ZeroMQ/Internal.pm6
+++ b/lib/Cro/ZeroMQ/Internal.pm6
@@ -105,6 +105,7 @@ role Cro::ZeroMQ::Source::Impure does Cro::Source does Cro::ZeroMQ::Component::I
             start {
                 loop {
                     last if $closer;
+                    CATCH { default { .rethrow unless $closer } }
                     my $event = poll_one(self!socket, 100, :in);
                     if $event > 0 {
                         $messages.emit: Cro::ZeroMQ::Message.new(parts => self!socket.receivemore);
@@ -133,6 +134,7 @@ role Cro::ZeroMQ::Source::Pure does Cro::Source does Cro::ZeroMQ::Component::Pur
             start {
                 loop {
                     last if $closer;
+                    CATCH { default { .rethrow unless $closer } }
                     my $event = poll_one($isocket, 100, :in);
                     if $event > 0 {
                         $messages.emit: Cro::ZeroMQ::Message.new(parts => $isocket.receivemore);


### PR DESCRIPTION
This PR solves two problems:

1. Stopping a service results in `X::AdHoc` produced by `Net::ZMQ::poll_one` because of a closed socket.
2. Polling threads started by `Cro::ZeroMQ::Source::Impure` and `Cro::ZeroMQ::Source::Pure` are not always ready to accept messages by the time the first ones are submitted. It was breaking _t/zeromq-xpub-xsub.t_ test.
